### PR TITLE
change from internal integrator to DiffEq.jl (only IZ)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,10 @@ uuid = "9d8b7fda-1049-58bc-9481-071a9f369938"
 version = "0.1.0"
 
 [deps]
+DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -12,9 +15,9 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Reexport = "0.2"
-Requires = "0.5, 1"
+Requires = "1"
 UnPack = "1"
-Unitful = "0.17, 0.18, 1"
+Unitful = "1"
 julia = "1"
 
 [extras]

--- a/examples/if_neuron.jl
+++ b/examples/if_neuron.jl
@@ -1,8 +1,10 @@
-using Plots, SNN
+using Plots, SpikingNeuralNetworks
+
+const SNN = SpikingNeuralNetworks
 
 E = SNN.IF(;N = 1)
 E.I = [11]
 SNN.monitor(E, [:v, :fire])
 
-SNN.sim!([E], []; duration = 300ms)
+SNN.sim!([E], []; duration = 400SNN.ms)
 SNN.vecplot(E, :v) |> display

--- a/examples/iz_neuron.jl
+++ b/examples/iz_neuron.jl
@@ -1,24 +1,35 @@
-using Plots, SNN
+using Plots, SpikingNeuralNetworks
+const SNN = SpikingNeuralNetworks
 
-RS = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.2, c = -65, d = 8))
-IB = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.2, c = -55, d = 4))
-CH = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.2, c = -50, d = 2))
-FS = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.1, b = 0.2, c = -65, d = 2))
-TC1 = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.25, c = -65, d = 0.05))
-TC2 = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.25, c = -65, d = 0.05))
-RZ = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.1, b = 0.26, c = -65, d = 2))
-LTS = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.1, b = 0.25, c = -65, d = 2))
-P = [RS, IB, CH, FS, TC1, TC2, RZ, LTS]
+v0 = fill(-65.0, 6)
+u0 = fill(0.2*-65, 6)
+vu0 = SNN.ArrayPartition(v0, u0)
+p = SNN.IZParameter()
+tspan = [0.0,100.0]
+cb = SNN.DiscreteCallback(SNN.fire,SNN.affect!)
+prob = SNN.ODEProblem(SNN.integrate!, vu0, tspan, p)
 
-SNN.monitor(P, [:v])
-T = 2second
-for t = 0:T
-    for p in [RS, IB, CH, FS, LTS]
-        p.I = [10]
-    end
-    TC1.I = [(t < 0.2T) ? 0mV : 2mV]
-    TC2.I = [(t < 0.2T) ? -30mV : 0mV]
-    RZ.I =  [(0.5T < t < 0.6T) ? 10mV : 0mV]
-    SNN.sim!(P, [], 0.1ms)
-end
-SNN.vecplot(P, :v) |> display
+sol = SNN.solve(prob,SNN.Tsit5();callback = cb)
+
+#RS = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.2, c = -65, d = 8))
+#IB = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.2, c = -55, d = 4))
+#CH = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.2, c = -50, d = 2))
+#FS = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.1, b = 0.2, c = -65, d = 2))
+#TC1 = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.25, c = -65, d = 0.05))
+#TC2 = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.02, b = 0.25, c = -65, d = 0.05))
+#RZ = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.1, b = 0.26, c = -65, d = 2))
+#LTS = SNN.IZ(;N = 1, param = SNN.IZParameter(;a = 0.1, b = 0.25, c = -65, d = 2))
+#P = [RS, IB, CH, FS, TC1, TC2, RZ, LTS]
+
+#SNN.monitor(P, [:v])
+#T = 2second
+#for t = 0:T
+#    for p in [RS, IB, CH, FS, LTS]
+#        p.I = [10]
+#    end
+#    TC1.I = [(t < 0.2T) ? 0mV : 2mV]
+#    TC2.I = [(t < 0.2T) ? -30mV : 0mV]
+#    RZ.I =  [(0.5T < t < 0.6T) ? 10mV : 0mV]
+#    SNN.sim!(P, [], 0.1ms)
+#end
+#SNN.vecplot(P, :v) |> display

--- a/src/SpikingNeuralNetworks.jl
+++ b/src/SpikingNeuralNetworks.jl
@@ -8,6 +8,9 @@ using SparseArrays
 using Reexport
 using Requires
 using UnPack
+using OrdinaryDiffEq
+#using DifferentialEquations
+using RecursiveArrayTools
 #using Unitful
 #using Unitful.DefaultSymbols
 #@reexport using Utils

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,34 +1,91 @@
-function sim!(P, C, dt)
-    for p in P
-        integrate!(p, p.param, Float32(dt))
-        record!(p)
+function vars(X)
+    map(p->p=>getfield(X,p), filter(x->x != :param, fieldnames(typeof(X))))
+end
+condition(X, u) = false
+affect!(X, u) = nothing
+function all_condition(u,t,integrator)
+    u = u.x
+    p = integrator.p[2]
+    trigger = false
+    for i in 1:length(u.x)
+        for j in 1:length(u.x[i].x)
+            _u = u.x[i].x[j]
+            _p = p[i][j]
+            trigger |= condition(_p, _u)
+        end
     end
-    for c in C
-        forward!(c, c.param)
-        record!(c)
+    return trigger
+end
+function all_affect!(integrator)
+    u = integrator.u.x
+    p = integrator.p[2]
+    for i in 1:length(u.x)
+        for j in 1:length(u.x[i].x)
+            _u = u.x[i].x[j]
+            _p = p[i][j]
+            affect!(_p, _u)
+        end
     end
 end
 
-function sim!(P, C; dt = 0.1ms, duration = 10ms)
-    for t = 0ms:dt:duration
-        sim!(P, C, dt)
+function prepare(N, S; tspan, train=true)
+    uN = ArrayPartition(map(x->ArrayPartition(last.(vars(x))...), N)...)
+    uS = ArrayPartition(map(x->ArrayPartition(last.(vars(x))...), S)...)
+    u = Remapper(ArrayPartition(uN, uS))
+    _u = similar(u)
+
+    p = (N, S)
+
+    return ODEProblem(_sim!, u, tspan, (train, p))
+end
+function restore!(u, p)
+    u = u.x # unwrap Remapper
+    uN, uS = u.x
+    train, p = p
+    pN, pS = p
+    for idx in 1:length(uN.x)
+        _pN = pN[idx]
+        v = first.(vars(_pN))
+        for vidx in 1:length(v)
+            setfield!(_pN, v[vidx], uN.x[idx].x[vidx])
+        end
     end
+    for idx in 1:length(uS.x)
+        _pS = pS[idx]
+        v = first.(vars(_pS))
+        for vidx in 1:length(v)
+            setfield!(_pS, v[vidx], uS.x[idx].x[vidx])
+        end
+    end
+end
+function _sim!(du, u, p, t)
+    du, u = du.x, u.x # unwrap Remapper
+    dN, dS = du.x
+    N, S = u.x
+    train, p = p
+    pN, pS = p
+    for idx in 1:length(N.x)
+        integrate!(dN.x[idx], N.x[idx], pN[idx], t)
+    end
+    for idx in 1:length(S.x)
+        dS.x[idx] .= 0 # Hack to prevent NaN when train == false
+        forward!(dS.x[idx], S.x[idx], pS[idx], t)
+        train && plasticity!(dS.x[idx], S.x[idx], pS[idx], t)
+    end
+end
+function sim!(N, S; tspan, alg=Tsit5(), reltol=1e-3, abstol=1e-3, kwargs...)
+    prob = prepare(N, S; tspan=tspan, kwargs...)
+    cb = DiscreteCallback(all_condition, all_affect!)
+    sol = solve(prob, alg; reltol=reltol, abstol=abstol, callback=cb)
+    restore!(last(sol.u), prob.p)
+    (prob, sol)
 end
 
-function train!(P, C, dt, t = 0)
-    for p in P
-        integrate!(p, p.param, Float32(dt))
-        record!(p)
-    end
-    for c in C
-        forward!(c, c.param)
-        plasticity!(c, c.param, Float32(dt), Float32(t))
-        record!(c)
-    end
-end
+## old API
 
-function train!(P, C; dt = 0.1ms, duration = 10ms)
-    for t = 0ms:dt:duration
-        train!(P, C, Float32(dt), Float32(t))
-    end
-end
+# FIXME: dt and duration
+sim!(N, S, dt; kwargs...) = sim!(N, S; tspan=(0ms, dt), kwargs...)
+train!(N, S, dt, t=0ms; kwargs...) =
+    sim!(N, S; tspan=(t, dt), train=true, kwargs...)
+train!(P, C; dt=0.1ms, duration=10ms) =
+    sim!(N, S; tspan=(0ms, duration), train=true, kwargs...)

--- a/src/neuron/hh.jl
+++ b/src/neuron/hh.jl
@@ -32,15 +32,15 @@ function integrate!(p::HH, param::HHParameter, dt::Float32)
     @unpack Cm, gl, El, Ek, En, gn, gk, Vt, τe, τi, Ee, Ei = param
     @inbounds for i = 1:N
         m[i] += dt * (0.32f0 * (13f0 - v[i] + Vt) / (exp((13f0 - v[i] + Vt) / 4f0) - 1f0) * (1f0 - m[i]) -
-        0.28f0 * (v[i] - Vt - 40f0) / (exp((v[i] - Vt - 40f0) / 5f0) - 1f0) * m[i])
+                0.28f0 * (v[i] - Vt - 40f0) / (exp((v[i] - Vt - 40f0) / 5f0) - 1f0) * m[i])
         n[i] += dt * (0.032f0 * (15f0 - v[i] + Vt) / (exp((15f0 - v[i] + Vt) / 5f0) - 1f0) * (1f0 - n[i]) -
-        0.5f0 * exp((10f0 - v[i] + Vt) / 40f0) * n[i])
+                0.5f0 * exp((10f0 - v[i] + Vt) / 40f0) * n[i])
         h[i] += dt * (0.128f0 * exp((17f0 - v[i] + Vt) / 18f0) * (1f0 - h[i]) -
-        4f0 / (1f0 + exp((40f0 - v[i] + Vt) / 5f0)) * h[i])
-        v[i] += dt / Cm * ( I[i] + gl * (El - v[i]) + ge[i] * (Ee - v[i]) + gi[i] * (Ei - v[i]) +
-        gn * m[i]^3 * h[i] * (En - v[i]) + gk * n[i]^4 * (Ek - v[i]) )
-        ge[i] += dt * -ge[i] / τe
-        gi[i] += dt * -gi[i] / τi
+                4f0 / (1f0 + exp((40f0 - v[i] + Vt) / 5f0)) * h[i])
+        v[i] = dt / Cm * ( I[i] + gl * (El - v[i]) + ge[i] * (Ee - v[i]) + gi[i] * (Ei - v[i]) +
+                gn * m[i]^3 * h[i] * (En - v[i]) + gk * n[i]^4 * (Ek - v[i]) )
+        ge[i] = dt * -ge[i] / τe
+        gi[i] = dt * -gi[i] / τi
     end
     @inbounds for i = 1:N
         fire[i] = v[i] > -20f0

--- a/src/synapse/spiking_synapse.jl
+++ b/src/synapse/spiking_synapse.jl
@@ -6,67 +6,73 @@
     ΔApost::FT = -ΔApre * τpre / τpost * 1.05
 end
 
-@snn_kw mutable struct SpikingSynapse{VIT=Vector{Int32},VFT=Vector{Float32},VBT=Vector{Bool}}
+@snn_kw mutable struct SpikingSynapse{MFT=SparseMatrixCSC{Float32},VFT=Vector{Float32},VBT=Vector{Bool}}
     param::SpikingSynapseParameter = SpikingSynapseParameter()
-    rowptr::VIT # row pointer of sparse W
-    colptr::VIT # column pointer of sparse W
-    I::VIT      # postsynaptic index of W
-    J::VIT      # presynaptic index of W
-    index::VIT  # index mapping: W[index[i]] = Wt[i], Wt = sparse(dense(W)')
-    W::VFT  # synaptic weight
-    tpre::VFT = zero(W) # presynaptic spiking time
-    tpost::VFT = zero(W) # postsynaptic spiking time
-    Apre::VFT = zero(W) # presynaptic trace
-    Apost::VFT = zero(W) # postsynaptic trace
-    fireI::VBT # postsynaptic firing
-    fireJ::VBT # presynaptic firing
+    N::Int # input length
+    M::Int # output length
+    W::MFT  # synaptic weight
+    tpre::VFT = zeros(eltype(VFT), N) # presynaptic spiking time
+    tpost::VFT = zeros(eltype(VFT), M) # postsynaptic spiking time
+    Apre::VFT = zeros(eltype(VFT), N) # presynaptic trace
+    Apost::VFT = zeros(eltype(VFT), M) # postsynaptic trace
+    firePre::VBT # presynaptic firing
+    firePost::VBT # postsynaptic firing
     g::VFT # postsynaptic conductance
     records::Dict = Dict()
 end
+vars(ss::SpikingSynapse) = (:W=>ss.W,:g=>ss.g,:Apre=>ss.Apre,:Apost=>ss.Apost)
 
 function SpikingSynapse(pre, post, sym; σ = 0.0, p = 0.0, kwargs...)
-    w = σ * sprand(post.N, pre.N, p)
-    rowptr, colptr, I, J, index, W = dsparse(w)
-    fireI, fireJ = post.fire, pre.fire
+    W = σ * sprand(post.N, pre.N, p)
+    firePost, firePre = post.fire, pre.fire
     g = getfield(post, sym)
-    SpikingSynapse(;@symdict(rowptr, colptr, I, J, index, W, fireI, fireJ, g)..., kwargs...)
+    SpikingSynapse(;@symdict(W, firePre, firePost, g)..., N=pre.N, M=post.N, kwargs...)
 end
 
-function forward!(c::SpikingSynapse, param::SpikingSynapseParameter)
-    @unpack colptr, I, W, fireJ, g = c
-    @inbounds for j in 1:(length(colptr) - 1)
-        if fireJ[j]
-            for s in colptr[j]:(colptr[j+1] - 1)
-                g[I[s]] += W[s]
-            end
-        end
+function forward!(du, u, p::SpikingSynapse, t)
+    @unpack firePre, firePost = p
+    W, g, Apre, Apost = u.x
+    dW, dg, dApre, dApost = du.x
+    # FIXME: Use broadcast
+    for j in 1:length(firePost)
+        dg[j] += firePost[j] * sum(W[j,:])
     end
+    # FIXME: Remove me
+    #dApre .= 0
+    #dApost .= 0
 end
 
-function plasticity!(c::SpikingSynapse, param::SpikingSynapseParameter, dt::Float32, t::Float32)
-    @unpack rowptr, colptr, I, J, index, W, tpre, tpost, Apre, Apost, fireI, fireJ, g = c
-    @unpack τpre, τpost, Wmax, ΔApre, ΔApost = param
-    @inbounds for j in 1:(length(colptr) - 1)
-        if fireJ[j]
-            for s in colptr[j]:(colptr[j+1] - 1)
-                Apre[s] *= exp32(- (t - tpre[s]) / τpre)
-                Apost[s] *= exp32(- (t - tpost[s]) / τpost)
-                Apre[s] += ΔApre
-                tpre[s] = t
-                W[s] = clamp(W[s] + Apost[s], 0f0, Wmax)
-            end
-        end
+function plasticity!(du,u,p::SpikingSynapse,t)
+    W, g, Apre, Apost = u.x
+    dW, dg, dApre, dApost = du.x
+    @unpack tpre, tpost, firePre, firePost = p
+    @unpack τpre, τpost, Wmax, ΔApre, ΔApost = p.param
+
+    # Update traces based on spike activity
+    #dApre[firePre] .= Apre[firePre] .* exp.(- (t .- tpre[firePre]) ./ τpre)
+    #dApost[firePost] .= Apost[firePost] .* exp.(- (t .- tpost[firePost]) ./ τpost)
+
+    # Decay traces
+    #dApre[firePre] .-= ΔApre
+    #dApost[firePost,:] .-= ΔApost
+
+    # Modify weights
+    dW[firePost, firePre] .= Apost[firePost] .+ transpose(Apre[firePre])
+
+    # FIXME: Clamp weights
+    #dW .-= dW .+ clamp.(W, zero(Wmax), Wmax)
+end
+
+function condition(sn::SpikingSynapse, u)
+    W = u.x[1]
+    any(W) do w
+        (w < 0) || (w > sn.param.Wmax)
     end
-    @inbounds for i in 1:(length(rowptr) - 1)
-        if fireI[i]
-            for st in rowptr[i]:(rowptr[i+1] - 1)
-                s = index[st]
-                Apre[s] *= exp32(- (t - tpre[s]) / τpre)
-                Apost[s] *= exp32(- (t - tpost[s]) / τpost)
-                Apost[s] += ΔApost
-                tpost[s] = t
-                W[s] = clamp(W[s] + Apre[s], 0f0, Wmax)
-            end
-        end
+end
+function affect!(sn::SpikingSynapse, u)
+    W = u.x[1]
+    Wmax = sn.param.Wmax
+    for idx in 1:length(W)
+        W[idx] = clamp(W[idx], zero(Wmax), Wmax)
     end
 end


### PR DESCRIPTION
This is only a first try and so far introduces breaking changes!

What works:
Integration of several IZ neurons over time (see examples/iz_neuron.jl) in a broadcasting friendly manner (thanks a lot to @jpsamaroo).

Questions that arise for me now:
- can parameters be in ArrayPartitions, too? So that we can have different types of neurons in one layer?
- do we need the IZ struct additionally to the IZ Parameter? Is that now better handled through the fire and affect! functions?

Next steps (as suggested by @jpsamaroo):
- “thread” do parameter through functions leading from sim! to integrate! for in-place (IIP)

-  OOP has to be figured out later (for Autodiff, if we want that, low priority)